### PR TITLE
Ordenamiento usuarios Leaderboard

### DIFF
--- a/imports/ui/components/Leaderboard.jsx
+++ b/imports/ui/components/Leaderboard.jsx
@@ -15,6 +15,12 @@ class Leaderboard extends Component {
 			return (
 				this.props.users.map((user, index) => {
 					return <LeaderboardEntry user = {user} pos={index+1} key={index}/>
+					/*Brandon Bohórquez: Los usuarios en el Leaderboard salen en distintas posiciones
+					                     al iniciar sesión con cuentas diferentes, es decir que el Leaderboard
+						             no se muestra igual ante todos los usuarios. 
+					                     Se debe revisar si el ordenamiento se está realizando correctamente
+			                                     puesto que el ordenamiento de usuarios en el Leaderboard no debería cambiar
+					  		     y debería ser igual para cualquier usuario loggeado. */
 				})
 			);
 		else


### PR DESCRIPTION
Los usuarios en el Leaderboard salen en distinto orden al iniciar sesión con cuentas diferentes. El Leaderboard debería mostrarse en el mismo orden ante todos los usuarios.