### PR TITLE
ID de las partidas actuales

### DIFF
--- a/imports/ui/components/SpectateList.jsx
+++ b/imports/ui/components/SpectateList.jsx
@@ -17,6 +17,16 @@ class SpectateList extends React.Component{
 				return (
 					<li className="list-group-item d-flex justify-content-between align-items-center">
           			<h5 className="mb-1">{game._id}</h5>
+						{/*Brandon Bohórquez: Mostrar el id de las partidas actuales no es muy conveniente
+						                      puesto que éste carece de sentido para el usuario final 
+								      (dado que es sólamente un string aleatorio), sería mejor
+								      mostrar otro tipo de información asociada a la partida tal como
+								      los jugadores que están involucrados.
+								      
+								      Esto afecta directamente la usabilidad puesto que el usuario no
+								      sabe qué significado tiene dicho id, lo que puede llegar a ser 
+								      confuso para él.
+						*/}
           			<button className="btn" onClick={() => this.spectate(game._id)}>Spectate</button>
 					</li>
 					)


### PR DESCRIPTION
No es muy conveniente mostrar el id de las partidas actuales ya que el usuario no encontrará sentido alguno en éste, lo que puede afectar la usabilidad de la aplicación.